### PR TITLE
Removing duplicate barcodes

### DIFF
--- a/R/combineContigs.R
+++ b/R/combineContigs.R
@@ -147,6 +147,10 @@ combineContigs <- function(df,
         c <- paste(samples[i], "_", ID[i], sep="")
         names <- c(names, c)}
     names(final) <- names
+  
+    for (i in seq_along(final)) {
+    final[[i]] <- final[[i]][!duplicated(final[[i]]$barcode),]
+  }
 
     return(final)
 }

--- a/R/combineContigs.R
+++ b/R/combineContigs.R
@@ -93,7 +93,6 @@ combineContigs <- function(df,
             Con.df[Con.df == "NA_NA_NA_NA"] <- NA #remove the na when nt+gene is called later
             data3 <- merge(data2[,-which(names(data2) %in% c("TCR1","TCR2"))], Con.df, by = "barcode")
             data3 <- data3[, c("barcode", "sample", "ID", "TCR1", "cdr3_aa1", "cdr3_nt1", "TCR2", "cdr3_aa2", "cdr3_nt2", "CTgene", "CTnt", "CTaa", "CTstrict")]
-            data3 <- data3[!duplicated(data3$barcode),]
             final[[i]] <- data3
         }
     }
@@ -138,7 +137,6 @@ combineContigs <- function(df,
             Con.df[Con.df == "NA_NA_NA_NA"] <- NA #remove the na when nt+gene is called later
             data3 <- merge(data2, Con.df[,-which(names(Con.df) %in% c("IGH","IGLC"))], by = "barcode")
             data3 <- data3[, c("barcode", "sample", "ID", "IGH", "cdr3_aa1", "cdr3_nt1", "IGLC", "cdr3_aa2", "cdr3_nt2", "CTgene", "CTnt", "CTaa", "CTstrict")]
-            data3 <- data3[!duplicated(data3$barcode),]
             final[[i]] <- data3
         }
     }


### PR DESCRIPTION
combineContigs function now also removes duplicate barcodes which appear when 1 cell has both alpha and beta TCR chains (or heavy and light BCR).