### PR TITLE
Fix index for multiple alpha/beta chains

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -223,14 +223,14 @@ parseTCR <- function(Con.df, unique_df, data2) {
                 Con.df[y,tcr2_lines]<-data2[location.i[2],data2_lines] }
         } else if (length(location.i) == 3) { 
             if (is.na(data2[location.i[1],c("TCR1")])) { 
-                Con.df[y,tcr2_lines]<-data2[location.i[1],data2_lines] 
+                Con.df[y,tcr2_lines]<-data2[location.i[1],data2_lines]
                 if (is.na(data2[location.i[2],c("TCR1")])) { 
                     TRdf <- paste(Con.df[y, tcr2_lines],
                         data2[location.i[2], data2_lines],sep=";") 
                     Con.df[y,tcr2_lines] <- TRdf 
                     Con.df[y,tcr1_lines] <- data2[location.i[3],data1_lines] 
                 } else { # if the 2nd location is occupied by TRA
-                    Con.df[y,tcr1_lines] <- data2[location.i[1],data1_lines] 
+                    Con.df[y,tcr1_lines] <- data2[location.i[2],data1_lines] ##HERE
                     if (is.na(data2[location.i[3],c("TCR1")])) { 
                         TRdf <- paste(Con.df[y, tcr2_lines],
                             data2[location.i[3], data2_lines],sep=";") 


### PR DESCRIPTION
I believe there was an incorrect index in the parseTCR utility function, which lead to TCR-beta chains reported as alpha chains. I flagged the line of the change with the comment ##HERE