### PR TITLE
Add filterMulti in combineBCR function

### DIFF
--- a/R/combineContigs.R
+++ b/R/combineContigs.R
@@ -176,7 +176,14 @@ combineBCR <- function(df,
         df[[i]]$sample <- samples[i]
         df[[i]]$ID <- ID[i]
         if (filterMulti) {
+                    # Keep IGH / IGK / IGL info in save_chain
+                    df[[i]]$save_chain=df[[i]]$chain
+                    # Collapse IGK and IGL chains
+                    df[[i]]$chain=ifelse(df[[i]]$chain=="IGH","IGH","IGLC")
                     df[[i]] <- filteringMulti(df[[i]])
+                    # Get back IGK / IGL distinction
+                    df[[i]]$chain=df[[i]]$save_chain
+                    df[[i]]$save_chain=NULL
         }
     }
     if (!is.null(samples)) {

--- a/R/combineContigs.R
+++ b/R/combineContigs.R
@@ -152,6 +152,7 @@ combineTCR <- function(df,
 #' similarity of sequence will be used for clustering.
 #' @param removeNA This will remove any chain without values.
 #' @param removeMulti This will remove barcodes with greater than 2 chains.
+#' @param filterMulti This option will allow for the selection of the 2 
 #' @import dplyr
 #' @export
 #' @return List of clonotypes for individual cell barcodes
@@ -161,7 +162,8 @@ combineBCR <- function(df,
                        call.related.clones = TRUE,
                        threshold = 0.85,
                        removeNA = FALSE, 
-                       removeMulti = FALSE) {
+                       removeMulti = FALSE,
+                      filterMulti = FALSE) {
     df <- checkList(df)
     df <- checkContigs(df)
     out <- NULL
@@ -170,11 +172,13 @@ combineBCR <- function(df,
     chain2 <- "light"
     for (i in seq_along(df)) {
         df[[i]] <- subset(df[[i]], chain %in% c("IGH", "IGK", "IGL"))
-        df[[i]] <- df[[i]] %>% group_by(barcode,chain) %>% 
-          slice_max(n=1,order_by=reads, with_ties = FALSE)
+        #df[[i]] <- df[[i]] %>% group_by(barcode,chain) %>% slice_max(n=1,order_by=reads, with_ties = FALSE)
         df[[i]]$sample <- samples[i]
         df[[i]]$ID <- ID[i]
-        df[[i]] <- filteringMulti(df[[i]]) }
+        if (filterMulti) {
+                    df[[i]] <- filteringMulti(df[[i]])
+        }
+    }
     if (!is.null(samples)) {
       out <- modifyBarcodes(df, samples, ID)
     } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -366,38 +366,34 @@ parseBCR <- function (Con.df, unique_df, data2) {
   for (y in seq_along(unique_df)) {
     barcode.i <- Con.df$barcode[y]
     location.i <- which(barcode.i == data2$barcode)
-    if (length(location.i) == 2) {
-      if (!is.na(data2[location.i[1], c("IGHct")])) {
-        Con.df[y, heavy_lines] <- data2[location.i[1], h_lines]
-        if(is.na(data2[location.i[2], c("IGHct")])) {
-          if (!is.na(data2[location.i[2], c("IGLct")])) {
-            Con.df[y, light_lines] <- data2[location.i[2], l_lines]
-          } else if(!is.na(data2[location.i[2], c("IGKct")])) {
-            Con.df[y, light_lines] <- data2[location.i[2], k_lines]
-          }
+    
+    for (z in seq_along(location.i)) {
+      where.chain <- data2[location.i[z],"chain"]
+      
+      if (where.chain == "IGH") {
+        if(is.na(Con.df[y,"IGH"])) {
+          Con.df[y,heavy_lines] <- data2[location.i[z],h_lines]
+        } else {
+          Con.df[y,heavy_lines] <- paste(Con.df[y, heavy_lines],
+                                         data2[location.i[z],h_lines],sep=";") 
         }
-      } else if (!is.na(data2[location.i[2], c("IGHct")])) {
-        Con.df[y, heavy_lines] <- data2[location.i[2], h_lines]
-        if(is.na(data2[location.i[1], c("IGHct")])) {
-          if (!is.na(data2[location.i[1], c("IGLct")])) {
-            Con.df[y, light_lines] <- data2[location.i[1], l_lines]
-          } else if(!is.na(data2[location.i[1], c("IGKct")])) {
-            Con.df[y, light_lines] <- data2[location.i[1], k_lines]
-          }
+      } else if (where.chain == "IGK") {
+        if(is.na(Con.df[y,"IGLC"])) {
+          Con.df[y,light_lines] <- data2[location.i[z],k_lines]
+        } else {
+          Con.df[y,light_lines] <- paste(Con.df[y, light_lines],
+                                         data2[location.i[z],k_lines],sep=";") 
         }
-      }
-    }else if (length(location.i) == 1) {
-      chain.i <- data2$chain[location.i]
-      if (chain.i == "IGH") {
-        Con.df[y, heavy_lines] <- data2[location.i[1], h_lines]
-      }
-      else if (chain.i == "IGL") {
-        Con.df[y, light_lines] <- data2[location.i[1], l_lines]
-      }
-      else {
-        Con.df[y, light_lines] <- data2[location.i[1], k_lines]
+      }else if (where.chain == "IGL") {
+        if(is.na(Con.df[y,"IGLC"])) {
+          Con.df[y,light_lines] <- data2[location.i[z],l_lines]
+        } else {
+          Con.df[y,light_lines] <- paste(Con.df[y, light_lines],
+                                         data2[location.i[z],l_lines],sep=";") 
+        }
       }
     }
+    
   }
   return(Con.df)
 }

--- a/man/combineBCR.Rd
+++ b/man/combineBCR.Rd
@@ -30,6 +30,9 @@ similarity of sequence will be used for clustering.}
 \item{removeNA}{This will remove any chain without values.}
 
 \item{removeMulti}{This will remove barcodes with greater than 2 chains.}
+
+\item{filterMulti}{This option will allow for the selection of the 2 
+corresponding chains with the highest expression for a single barcode.}
 }
 \value{
 List of clonotypes for individual cell barcodes


### PR DESCRIPTION
Hi Nick,

Here is a pull request to add the filterMulti parameter in the combineBCR function (like in the combineTCR function) in case we want to keep and paste multiple IGH/IGLC results for the same barcode.
I had to adjust filteringMulti input (to consider both IGK and IGL as IGLC) because I had some issues with barcodes having multiple BCR results. For exemple, I had one case with 1 IGH + 1 IGK + 1IGL with the IGK and IGL having the highest number of reads. The IGK and IGL were kept and the IGH were lost.
I also modified the parseBCR function to make the paste work (inspired from the parseTCR function).

Simon
