### PR TITLE
Update clonalQuant.R

### DIFF
--- a/R/clonalQuant.R
+++ b/R/clonalQuant.R
@@ -77,7 +77,6 @@ clonalQuant <- function(input.data,
       ylab <- "Percent of Unique Clonotype"
    } else { 
       y <- "contigs"
-      x <- group.by
       ylab <- "Unique Clonotypes"
    }
   


### PR DESCRIPTION
This fix prevents clonalQuant from crashing when `scale=F` and `group.by` are used together. The deleted line was reassigning `x` to the `group.by` variable which is NULL when no grouping is used. `x` is correctly defined in lines 26-33.