### PR TITLE
Use file.path() to build export file path

### DIFF
--- a/R/exportClones.R
+++ b/R/exportClones.R
@@ -52,9 +52,9 @@ exportClones <- function(input.data,
   }
   
   if(is.null(dir)) {
-    dir <- "./"
+    dir <- "."
   }
-  filepath <- paste0(dir, file.name)
+  filepath <- file.path(dir, file.name)
   write.csv(mat, file = filepath)
 }
 


### PR DESCRIPTION
This PR improves/simplifies the path building for `exportClones()`. 

By replacing `paste0` with the `file.path` function, users do not have to include `/` in either the `dir` or `file.name` param when the exported file is to be saved in a directory other than the currect one, which I think is more intuitive.