### PR TITLE
Allow selecting a single diversity metric in 'clonalDiversity()'

### DIFF
--- a/R/clonalDiversity.R
+++ b/R/clonalDiversity.R
@@ -129,7 +129,7 @@ clonalDiversity <- function(input.data,
       }
     }
     colnames(mat) <- c("shannon", "inv.simpson", "norm.entropy", "gini.simpson", "chao1", "ACE")
-    mat <- mat[,colnames(mat) %in% metrics]
+    mat <- mat[,colnames(mat) %in% metrics,drop=FALSE]
     if (is.null(group.by)) {
       group.by <- "Group"
     }


### PR DESCRIPTION
This PR fix a simple bug to allow users to select and show a single diversity metric in `clonalDiversity()`

```r
Error in mat[, group.by] <- names(input.data): incorrect number of subscripts on matrix
Traceback:

1. clonalDiversity(combined.TCR, cloneCall = "gene", chain = "both", metrics = "shannon")
```
