### PR TITLE
Fix 'ident' field name of sc object in '.grabMeta()'

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -198,7 +198,7 @@ is_seurat_or_se_object <- function(obj) {
     } else if (is_se_object(sc)){
         meta <- data.frame(colData(sc))
         rownames(meta) <- sc@colData@rownames
-        clu <- which(colnames(meta) == "ident")
+        clu <- which(colnames(meta) == "label") # as set by colLabels()
         colnames(meta)[clu] <- "ident"
     } else {
         stop("Object indicated is not of class 'Seurat' or 


### PR DESCRIPTION
This PR fix a simple bug in `.grabMeta()`. 
When the input is a `SingleCellExperiment`, the corresponding `ident` field in `colData` should be `label`. The fix should allow the correct selection of the column containing cell cluster labels.

```r
ERROR while rich displaying an object: Error in `geom_point()`:
! Problem while computing aesthetics.
ℹ Error occurred in the 1st layer.
Caused by error in `[.data.frame`:
! undefined columns selected
```