### PR TITLE
Fix TRUST4 loadContigs issue in #429

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, master, v2]
   pull_request:
-    branches: [main, master, v2]
+    branches: [main, master, v2, dev]
 
 name: R-CMD-check
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ docs
 vignettes/articles/scRep_example_full.rds
 .vscode
 qile
+dev
+.lintr

--- a/R/loadContigs.R
+++ b/R/loadContigs.R
@@ -110,7 +110,7 @@ loadContigs <- function(input, format = "10X") {
     loadFunc(rawDataDfList)
 }
 
-#' Formats TRUST4 data
+#Formats TRUST4 data
 #' @importFrom stringr str_split
 .parseTRUST4 <- function(df) {
 
@@ -122,7 +122,7 @@ loadContigs <- function(input, format = "10X") {
         if (length(which(is.na(df[[i]]$chain1))) == length(df[[i]]$chain1)) {
             chain2 <- matrix(ncol = 7, nrow = length(df[[i]]$chain1))
         } else {
-            chain2 <- str_split(df[[i]]$chain1, ",", simplify = TRUE)[, seq_len(7)]
+            chain2 <- str_split(df[[i]]$chain1, ",", simplify = TRUE)[, seq_len(7), drop = FALSE]
             chain2[chain2 == "*"] <- "None"
         }
         colnames(chain2) <- c("v_gene", "d_gene", "j_gene", "c_gene", "cdr3_nt", "cdr3", "reads")
@@ -131,14 +131,14 @@ loadContigs <- function(input, format = "10X") {
         if (length(which(is.na(df[[i]]$chain2))) == length(df[[i]]$chain2)) {
             chain1 <- matrix(ncol = 7, nrow = length(df[[i]]$chain2))
         } else {
-            chain1 <- str_split(df[[i]]$chain2, ",", simplify = TRUE)[, seq_len(7)]
+            chain1 <- str_split(df[[i]]$chain2, ",", simplify = TRUE)[, seq_len(7), drop = FALSE]
             chain1[chain1 == "*"] <- "None"
         }
-        colnames(chain1) <- c("v_gene", "d_gene", "j_gene", "c_gene", "cdr3_nt", "cdr3", "reads") # issue 429
+        colnames(chain1) <- c("v_gene", "d_gene", "j_gene", "c_gene", "cdr3_nt", "cdr3", "reads")
         chain1 <- data.frame(barcode = df[[i]][, 1], chain1)
         data2 <- rbind(chain1, chain2)
         data2[data2 == ""] <- NA
-        df[[i]] <- data2
+        df[[i]] <- data2 # is it necessary to drop rows that are fully NA with an existing barcode?
     }
 
     .chain.parser(df)

--- a/R/loadContigs.R
+++ b/R/loadContigs.R
@@ -5,7 +5,7 @@
 #' using data derived from filtered outputs of 10X Genomics, there is no
 #' need to use this function as the data is already compatible.
 #'
-#' The files that this function parses includes: 
+#' The files that this function parses includes:
 #' \itemize{
 #'   \item 10X =  "filtered_contig_annotations.csv"
 #'   \item AIRR = "airr_rearrangement.tsv"
@@ -30,7 +30,8 @@
 #' WAT3R <- read.csv("https://www.borch.dev/uploads/contigs/WAT3R_contigs.csv")
 #' contig.list <- loadContigs(WAT3R, format = "WAT3R")
 #'
-#' @param input The directory in which contigs are located or a list with contig elements
+#' @param input The directory in which contigs are located or a list with contig
+#' elements
 #' @param format The format of the single-cell contig, currently supporting:
 #' "10X", "AIRR", "BD", "Dandelion", "JSON", "MiXCR", "ParseBio", "Omniscope",
 #' "TRUST4", "WAT3R", and "Immcantation"
@@ -112,11 +113,13 @@ loadContigs <- function(input, format = "10X") {
 #' Formats TRUST4 data
 #' @importFrom stringr str_split
 .parseTRUST4 <- function(df) {
+
     for (i in seq_along(df)) {
+
         colnames(df[[i]])[1] <- "barcode"
         df[[i]][df[[i]] == "*"] <- NA
 
-        if(length(which(is.na(df[[i]]$chain1))) == length(df[[i]]$chain1)) {
+        if (length(which(is.na(df[[i]]$chain1))) == length(df[[i]]$chain1)) {
             chain2 <- matrix(ncol = 7, nrow = length(df[[i]]$chain1))
         } else {
             chain2 <- str_split(df[[i]]$chain1, ",", simplify = TRUE)[, seq_len(7)]
@@ -125,7 +128,7 @@ loadContigs <- function(input, format = "10X") {
         colnames(chain2) <- c("v_gene", "d_gene", "j_gene", "c_gene", "cdr3_nt", "cdr3", "reads")
         chain2 <- data.frame(barcode = df[[i]][, 1], chain2)
 
-        if(length(which(is.na(df[[i]]$chain2))) == length(df[[i]]$chain2)) {
+        if (length(which(is.na(df[[i]]$chain2))) == length(df[[i]]$chain2)) {
             chain1 <- matrix(ncol = 7, nrow = length(df[[i]]$chain2))
         } else {
             chain1 <- str_split(df[[i]]$chain2, ",", simplify = TRUE)[, seq_len(7)]
@@ -137,8 +140,16 @@ loadContigs <- function(input, format = "10X") {
         data2[data2 == ""] <- NA
         df[[i]] <- data2
     }
-    df <- .chain.parser(df)
-    return(df)
+
+    .chain.parser(df)
+}
+
+#Grabs the chain info from v_gene
+.chain.parser <- function(df) {
+    lapply(df, function(x) {
+        x$chain <- substr(x$v_gene, 1, 3)
+        x
+    })
 }
 
 #Formats wat3r data
@@ -204,14 +215,6 @@ loadContigs <- function(input, format = "10X") {
   }
   return(df)
 }
-#Grabs the chain info from v_gene
-.chain.parser <- function(df) {
-  for (i in seq_along(df)) {
-    df[[i]]$chain <- substr(df[[i]][,"v_gene"],1,3)
-  }
-  return(df)
-}
-   
 
 .parseOmniscope <- function(df) {
   for (i in seq_along(df)) {

--- a/R/loadContigs.R
+++ b/R/loadContigs.R
@@ -52,21 +52,23 @@ loadContigs <- function(input, format = "10X") {
     #Loading from directory, recursively
     df <- if (inherits(x = input, what = "character")) {
 
-        format.list <- list("WAT3R" = "barcode_results.csv",
-                            "10X" =  "filtered_contig_annotations.csv",
-                            "AIRR" = "airr_rearrangement.tsv",
-                            "Dandelion" = "all_contig_dandelion.tsv",
-                            "Immcantation" = "_data.tsv",
-                            "MiXCR" = "clones.tsv",
-                            "JSON" = ".json",
-                            "TRUST4" = "barcode_report.tsv",
-                            "BD" = "Contigs_AIRR.tsv",
-                            "Omniscope" =c("_OSB.csv", "_OST.csv"),
-                            "ParseBio" = "barcode_report.tsv")
+        format.list <- list(
+            "WAT3R" = "barcode_results.csv",
+            "10X" =  "filtered_contig_annotations.csv",
+            "AIRR" = "airr_rearrangement.tsv",
+            "Dandelion" = "all_contig_dandelion.tsv",
+            "Immcantation" = "_data.tsv",
+            "MiXCR" = "clones.tsv",
+            "JSON" = ".json",
+            "TRUST4" = "barcode_report.tsv",
+            "BD" = "Contigs_AIRR.tsv",
+            "Omniscope" = c("_OSB.csv", "_OST.csv"),
+            "ParseBio" = "barcode_report.tsv"
+        )
         file.pattern <- format.list[[format]]
         contig.files <- list.files(
             input,
-            paste0(file.pattern, collapse = "|"),
+            paste0("*", file.pattern, "$", collapse = "|"),
             recursive = TRUE,
             full.names = TRUE
         )
@@ -129,7 +131,7 @@ loadContigs <- function(input, format = "10X") {
           chain1 <- str_split(df[[i]]$chain2, ",", simplify = TRUE)[,seq_len(7)]
           chain1[chain1 == "*"] <- "None"
         }
-        colnames(chain1) <- c("v_gene", "d_gene", "j_gene", "c_gene", "cdr3_nt", "cdr3", "reads")
+        colnames(chain1) <- c("v_gene", "d_gene", "j_gene", "c_gene", "cdr3_nt", "cdr3", "reads") # issue 429
         chain1 <- data.frame(barcode = df[[i]][,1], chain1)
         data2 <- rbind(chain1, chain2)
         data2[data2 == ""] <- NA

--- a/R/loadContigs.R
+++ b/R/loadContigs.R
@@ -109,30 +109,30 @@ loadContigs <- function(input, format = "10X") {
     loadFunc(rawDataDfList)
 }
 
-#Formats TRUST4 data
+#' Formats TRUST4 data
 #' @importFrom stringr str_split
 .parseTRUST4 <- function(df) {
     for (i in seq_along(df)) {
         colnames(df[[i]])[1] <- "barcode"
         df[[i]][df[[i]] == "*"] <- NA
-       
+
         if(length(which(is.na(df[[i]]$chain1))) == length(df[[i]]$chain1)) {
-          chain2 <- matrix(ncol = 7, nrow = length(df[[i]]$chain1))
+            chain2 <- matrix(ncol = 7, nrow = length(df[[i]]$chain1))
         } else {
-          chain2 <- str_split(df[[i]]$chain1, ",", simplify = TRUE)[,seq_len(7)]
-          chain2[chain2 == "*"] <- "None"
+            chain2 <- str_split(df[[i]]$chain1, ",", simplify = TRUE)[, seq_len(7)]
+            chain2[chain2 == "*"] <- "None"
         }
         colnames(chain2) <- c("v_gene", "d_gene", "j_gene", "c_gene", "cdr3_nt", "cdr3", "reads")
-        chain2 <- data.frame(barcode = df[[i]][,1], chain2)
-       
+        chain2 <- data.frame(barcode = df[[i]][, 1], chain2)
+
         if(length(which(is.na(df[[i]]$chain2))) == length(df[[i]]$chain2)) {
-          chain1 <- matrix(ncol = 7, nrow = length(df[[i]]$chain2))
+            chain1 <- matrix(ncol = 7, nrow = length(df[[i]]$chain2))
         } else {
-          chain1 <- str_split(df[[i]]$chain2, ",", simplify = TRUE)[,seq_len(7)]
-          chain1[chain1 == "*"] <- "None"
+            chain1 <- str_split(df[[i]]$chain2, ",", simplify = TRUE)[, seq_len(7)]
+            chain1[chain1 == "*"] <- "None"
         }
         colnames(chain1) <- c("v_gene", "d_gene", "j_gene", "c_gene", "cdr3_nt", "cdr3", "reads") # issue 429
-        chain1 <- data.frame(barcode = df[[i]][,1], chain1)
+        chain1 <- data.frame(barcode = df[[i]][, 1], chain1)
         data2 <- rbind(chain1, chain2)
         data2[data2 == ""] <- NA
         df[[i]] <- data2

--- a/R/loadContigs.R
+++ b/R/loadContigs.R
@@ -50,7 +50,7 @@ loadContigs <- function(input, format = "10X") {
     ))
 
     #Loading from directory, recursively
-    df <- if (inherits(x = input, what = "character")) {
+    rawDataDfList <- if (inherits(x = input, what = "character")) {
 
         format.list <- list(
             "WAT3R" = "barcode_results.csv",
@@ -106,7 +106,7 @@ loadContigs <- function(input, format = "10X") {
         "ParseBio" = .parseParse
     )
 
-    loadFunc(df)
+    loadFunc(rawDataDfList)
 }
 
 #Formats TRUST4 data

--- a/man/clonalAbundance.Rd
+++ b/man/clonalAbundance.Rd
@@ -16,18 +16,18 @@ clonalAbundance(
 )
 }
 \arguments{
-\item{input.data}{The product of \code{\link{combineTCR}}, 
+\item{input.data}{The product of \code{\link{combineTCR}},
 \code{\link{combineBCR}}, or \code{\link{combineExpression}}.}
 
-\item{cloneCall}{How to call the clone - VDJC gene (\strong{gene}), 
+\item{cloneCall}{How to call the clone - VDJC gene (\strong{gene}),
 CDR3 nucleotide (\strong{nt}), CDR3 amino acid (\strong{aa}),
-VDJC gene + CDR3 nucleotide (\strong{strict}) or a custom variable 
+VDJC gene + CDR3 nucleotide (\strong{strict}) or a custom variable
 in the data.}
 
-\item{chain}{indicate if both or a specific chain should be used - 
+\item{chain}{indicate if both or a specific chain should be used -
 e.g. "both", "TRA", "TRG", "IGH", "IGL"}
 
-\item{scale}{Converts the graphs into density plots in order to show 
+\item{scale}{Converts the graphs into density plots in order to show
 relative distributions.}
 
 \item{group.by}{The variable to use for grouping}
@@ -38,29 +38,29 @@ to plot groups in order}
 \item{exportTable}{Returns the data frame used for forming the graph
 to the visualization.}
 
-\item{palette}{Colors to use in visualization - input any 
+\item{palette}{Colors to use in visualization - input any
 \link[grDevices]{hcl.pals}.}
 }
 \value{
-ggplot of the total or relative abundance of clones 
+ggplot of the total or relative abundance of clones
 across quanta
 }
 \description{
-Displays the number of clones at specific frequencies by sample 
+Displays the number of clones at specific frequencies by sample
 or group. Visualization can either be a line graph (
-\strong{scale} = FALSE) using calculated numbers or density 
-plot (\strong{scale} = TRUE). Multiple sequencing runs can 
-be group together using the group parameter. If a matrix 
-output for the data is preferred, set 
+\strong{scale} = FALSE) using calculated numbers or density
+plot (\strong{scale} = TRUE). Multiple sequencing runs can
+be group together using the group parameter. If a matrix
+output for the data is preferred, set
 \strong{exportTable} = TRUE.
 }
 \examples{
 #Making combined contig data
-combined <- combineTCR(contig_list, 
-                        samples = c("P17B", "P17L", "P18B", "P18L", 
+combined <- combineTCR(contig_list,
+                        samples = c("P17B", "P17L", "P18B", "P18L",
                                     "P19B","P19L", "P20B", "P20L"))
-clonalAbundance(combined, 
-                cloneCall = "gene", 
+clonalAbundance(combined,
+                cloneCall = "gene",
                 scale = FALSE)
 
 }

--- a/man/clonalSizeDistribution.Rd
+++ b/man/clonalSizeDistribution.Rd
@@ -16,36 +16,36 @@ clonalSizeDistribution(
 )
 }
 \arguments{
-\item{input.data}{The product of \code{\link{combineTCR}}, 
+\item{input.data}{The product of \code{\link{combineTCR}},
 \code{\link{combineBCR}}, or \code{\link{combineExpression}}.}
 
-\item{cloneCall}{How to call the clone - VDJC gene (\strong{gene}), 
+\item{cloneCall}{How to call the clone - VDJC gene (\strong{gene}),
 CDR3 nucleotide (\strong{nt}), CDR3 amino acid (\strong{aa}),
-VDJC gene + CDR3 nucleotide (\strong{strict}) or a custom variable 
+VDJC gene + CDR3 nucleotide (\strong{strict}) or a custom variable
 in the data.}
 
-\item{chain}{indicate if both or a specific chain should be used - 
+\item{chain}{indicate if both or a specific chain should be used -
 e.g. "both", "TRA", "TRG", "IGH", "IGL".}
 
 \item{method}{The clustering parameter for the dendrogram.}
 
-\item{threshold}{Numerical vector containing the thresholds 
+\item{threshold}{Numerical vector containing the thresholds
 the grid search was performed over.}
 
 \item{group.by}{The variable to use for grouping.}
 
 \item{exportTable}{Returns the data frame used for forming the graph.}
 
-\item{palette}{Colors to use in visualization - input any 
+\item{palette}{Colors to use in visualization - input any
 \link[grDevices]{hcl.pals}.}
 }
 \value{
 ggplot dendrogram of the clone size distribution
 }
 \description{
-This function produces a hierarchical clustering of clones by sample 
-using discrete gamma-GPD spliced threshold model. If using this 
-model please read and cite powerTCR (more info available at 
+This function produces a hierarchical clustering of clones by sample
+using discrete gamma-GPD spliced threshold model. If using this
+model please read and cite powerTCR (more info available at
 \href{https://pubmed.ncbi.nlm.nih.gov/30485278/}{PMID: 30485278}).
 }
 \details{
@@ -59,7 +59,7 @@ Where:
   \item{\eqn{\xi} is a shape parameter}
   \item{\eqn{x \ge \mu} if \eqn{\xi \ge 0} and \eqn{\mu \le x \le \mu - \sigma/\xi} if \eqn{\xi < 0}}
 }
-              
+
 The probability density function (pdf) for the \strong{Gamma Distribution} is given by:
 \deqn{f(x|\alpha, \beta) = \frac{x^{\alpha-1} e^{-x/\beta}}{\beta^\alpha \Gamma(\alpha)}}
 
@@ -73,8 +73,8 @@ Where:
 }
 \examples{
 #Making combined contig data
-combined <- combineTCR(contig_list, 
-                        samples = c("P17B", "P17L", "P18B", "P18L", 
+combined <- combineTCR(contig_list,
+                        samples = c("P17B", "P17L", "P18B", "P18L",
                                     "P19B","P19L", "P20B", "P20L"))
 clonalSizeDistribution(combined, cloneCall = "strict", method="ward.D2")
 

--- a/man/loadContigs.Rd
+++ b/man/loadContigs.Rd
@@ -9,33 +9,34 @@ loadContigs(input, format = "10X")
 \arguments{
 \item{input}{The directory in which contigs are located or a list with contig elements}
 
-\item{format}{The format of the single-cell contig, currently supporting: 
-"10X", "AIRR", "BD", "Dandelion", "JSON", "MiXCR", "ParseBio", "Omniscope", "TRUST4", and "WAT3R"}
+\item{format}{The format of the single-cell contig, currently supporting:
+"10X", "AIRR", "BD", "Dandelion", "JSON", "MiXCR", "ParseBio", "Omniscope",
+"TRUST4", "WAT3R", and "Immcantation"}
 }
 \value{
-List of contigs for compatibility  with \code{\link{combineTCR}} or 
+List of contigs for compatibility  with \code{\link{combineTCR}} or
 \code{\link{combineBCR}}
 }
 \description{
-This function generates a contig list and formats the data to allow for 
-function with  \code{\link{combineTCR}} or \code{\link{combineBCR}}. If 
-using data derived from filtered outputs of 10X Genomics, there is no 
+This function generates a contig list and formats the data to allow for
+function with  \code{\link{combineTCR}} or \code{\link{combineBCR}}. If
+using data derived from filtered outputs of 10X Genomics, there is no
 need to use this function as the data is already compatible.
 }
 \details{
-The files that this function parses includes:  
+The files that this function parses includes: 
 \itemize{
   \item 10X =  "filtered_contig_annotations.csv"
-  \item AIRR = "airr_rearrangement.tsv" 
-  \item BD = "Contigs_AIRR.tsv" 
-  \item Dandelion = "all_contig_dandelion.tsv" 
-  \item Immcantation = "data.tsv" 
+  \item AIRR = "airr_rearrangement.tsv"
+  \item BD = "Contigs_AIRR.tsv"
+  \item Dandelion = "all_contig_dandelion.tsv"
+  \item Immcantation = "data.tsv"
   \item JSON = ".json"
   \item ParseBio = "barcode_report.tsv"
   \item MiXCR = "clones.tsv"
-  \item Omniscope = ".csv" 
+  \item Omniscope = ".csv"
   \item TRUST4 = "barcode_report.tsv"
-  \item WAT3R = "barcode_results.csv" 
+  \item WAT3R = "barcode_results.csv"
 }
 }
 \examples{

--- a/man/loadContigs.Rd
+++ b/man/loadContigs.Rd
@@ -7,7 +7,8 @@
 loadContigs(input, format = "10X")
 }
 \arguments{
-\item{input}{The directory in which contigs are located or a list with contig elements}
+\item{input}{The directory in which contigs are located or a list with contig
+elements}
 
 \item{format}{The format of the single-cell contig, currently supporting:
 "10X", "AIRR", "BD", "Dandelion", "JSON", "MiXCR", "ParseBio", "Omniscope",
@@ -24,7 +25,7 @@ using data derived from filtered outputs of 10X Genomics, there is no
 need to use this function as the data is already compatible.
 }
 \details{
-The files that this function parses includes: 
+The files that this function parses includes:
 \itemize{
   \item 10X =  "filtered_contig_annotations.csv"
   \item AIRR = "airr_rearrangement.tsv"

--- a/man/percentAA.Rd
+++ b/man/percentAA.Rd
@@ -35,16 +35,16 @@ to plot groups in order}
 ggplot of stacked bar graphs of amino acid proportions
 }
 \description{
-This function the proportion of amino acids along the residues 
+This function the proportion of amino acids along the residues
 of the CDR3 amino acid sequence.
 }
 \examples{
 #Making combined contig data
-combined <- combineTCR(contig_list, 
-                        samples = c("P17B", "P17L", "P18B", "P18L", 
+combined <- combineTCR(contig_list,
+                        samples = c("P17B", "P17L", "P18B", "P18L",
                                     "P19B","P19L", "P20B", "P20L"))
-percentAA(combined, 
-          chain = "TRB", 
+percentAA(combined,
+          chain = "TRB",
           aa.length = 20)
 }
 \concept{Summarize_Repertoire}

--- a/man/positionalEntropy.Rd
+++ b/man/positionalEntropy.Rd
@@ -16,7 +16,7 @@ positionalEntropy(
 )
 }
 \arguments{
-\item{input.data}{The product of \code{\link{combineTCR}}, 
+\item{input.data}{The product of \code{\link{combineTCR}},
 \code{\link{combineBCR}}, or \code{\link{combineExpression}}}
 
 \item{chain}{"TRA", "TRB", "TRG", "TRG", "IGH", "IGL"}
@@ -28,7 +28,7 @@ to plot groups in order}
 
 \item{aa.length}{The maximum length of the CDR3 amino acid sequence.}
 
-\item{method}{The method to calculate the entropy/diversity - 
+\item{method}{The method to calculate the entropy/diversity -
 "shannon", "inv.simpson", "norm.entropy"}
 
 \item{exportTable}{Returns the data frame used for forming the graph}
@@ -39,20 +39,20 @@ to plot groups in order}
 ggplot of line graph of diversity by position
 }
 \description{
-This function the diversity amino acids along the residues 
-of the CDR3 amino acid sequence. Please see 
-\code{\link{clonalDiversity}} for more information on 
-the underlying methods for diversity/entropy calculations. 
-Positions without variance will have a value reported as 0 
+This function the diversity amino acids along the residues
+of the CDR3 amino acid sequence. Please see
+\code{\link{clonalDiversity}} for more information on
+the underlying methods for diversity/entropy calculations.
+Positions without variance will have a value reported as 0
 for the purposes of comparison.
 }
 \examples{
 #Making combined contig data
-combined <- combineTCR(contig_list, 
-                        samples = c("P17B", "P17L", "P18B", "P18L", 
+combined <- combineTCR(contig_list,
+                        samples = c("P17B", "P17L", "P18B", "P18L",
                                     "P19B","P19L", "P20B", "P20L"))
-positionalEntropy(combined, 
-                  chain = "TRB", 
+positionalEntropy(combined,
+                  chain = "TRB",
                   aa.length = 20)
 }
 \concept{Summarize_Repertoire}

--- a/man/positionalProperty.Rd
+++ b/man/positionalProperty.Rd
@@ -16,7 +16,7 @@ positionalProperty(
 )
 }
 \arguments{
-\item{input.data}{The product of \code{\link{combineTCR}}, 
+\item{input.data}{The product of \code{\link{combineTCR}},
 \code{\link{combineBCR}}, or \code{\link{combineExpression}}}
 
 \item{chain}{"TRA", "TRB", "TRG", "TRG", "IGH", "IGL"}
@@ -39,9 +39,9 @@ to plot groups in order}
 ggplot of line graph of diversity by position
 }
 \description{
-This function calculates the mean selected property for 
-amino acids along the residues of the CDR3 amino acid sequence. 
-The ribbon surrounding the individual line represents the 95% 
+This function calculates the mean selected property for
+amino acids along the residues of the CDR3 amino acid sequence.
+The ribbon surrounding the individual line represents the 95%
 confidence interval.
 }
 \details{
@@ -59,12 +59,12 @@ More information for the individual methods can be found at the following citati
 }
 \examples{
 #Making combined contig data
-combined <- combineTCR(contig_list, 
-                        samples = c("P17B", "P17L", "P18B", "P18L", 
+combined <- combineTCR(contig_list,
+                        samples = c("P17B", "P17L", "P18B", "P18L",
                                     "P19B","P19L", "P20B", "P20L"))
-positionalProperty(combined, 
+positionalProperty(combined,
                    chain = "TRB",
-                   method = "Atchley", 
+                   method = "Atchley",
                    aa.length = 20)
 }
 \author{

--- a/man/vizGenes.Rd
+++ b/man/vizGenes.Rd
@@ -17,47 +17,47 @@ vizGenes(
 )
 }
 \arguments{
-\item{input.data}{The product of \code{\link{combineTCR}}, 
+\item{input.data}{The product of \code{\link{combineTCR}},
 \code{\link{combineBCR}}, or \code{\link{combineExpression}}.}
 
-\item{x.axis}{Gene segments to separate the x-axis, such as "TRAV", 
+\item{x.axis}{Gene segments to separate the x-axis, such as "TRAV",
 "TRBD", "IGKJ".}
 
-\item{y.axis}{Variable to separate the y-axis, can be both categorical 
+\item{y.axis}{Variable to separate the y-axis, can be both categorical
 or other gene gene segments, such as "TRAV", "TRBD", "IGKJ".}
 
 \item{group.by}{Variable in which to group the diversity calculation.}
 
 \item{plot}{The type of plot to return - heatmap or barplot.}
 
-\item{order}{Categorical variable to organize the x-axis, either 
+\item{order}{Categorical variable to organize the x-axis, either
 "gene" or "variance"}
 
-\item{scale}{Converts the individual count of genes to proportion using 
+\item{scale}{Converts the individual count of genes to proportion using
 the total respective repertoire size}
 
 \item{exportTable}{Returns the data frame used for forming the graph.}
 
-\item{palette}{Colors to use in visualization - input any 
+\item{palette}{Colors to use in visualization - input any
 \link[grDevices]{hcl.pals}.}
 }
 \value{
 ggplot bar diagram or heatmap of gene usage
 }
 \description{
-This function will allow for the visualizing the distribution 
+This function will allow for the visualizing the distribution
 of the any VDJ and C gene of the TCR or BCR using heatmap or
-bar chart. This function requires assumes two chains were used in 
-defining clone, if not, it will default to the only chain 
+bar chart. This function requires assumes two chains were used in
+defining clone, if not, it will default to the only chain
 present regardless of the chain parameter.
 }
 \examples{
 #Making combined contig data
-combined <- combineTCR(contig_list, 
-                        samples = c("P17B", "P17L", "P18B", "P18L", 
+combined <- combineTCR(contig_list,
+                        samples = c("P17B", "P17L", "P18B", "P18L",
                                     "P19B","P19L", "P20B", "P20L"))
 
-vizGenes(combined, 
+vizGenes(combined,
          x.axis = "TRBV",
          y.axis = NULL,
          plot = "heatmap")


### PR DESCRIPTION
This is a fix for #429 

The issue ended up being that matrix subsetting in R reduces matricies to vectors when the subsetted result will only have 1 column/row which caused an error when trying to do `colnames()<-`. Fixed this by using drop = FALSE as the k argument in matrix subsetting. This may or may not be present in other functions too - haven't checked yet.

Also did some general reformatting and refactoring but no functionality has been affected.