### PR TITLE
drop all NA rows from loadContigs output & clean up imports

### DIFF
--- a/R/alluvialClones.R
+++ b/R/alluvialClones.R
@@ -62,8 +62,7 @@
 #' environment in addition to the visualization.
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals].
-#' 
-#' @import ggplot2
+#'
 #' @importFrom ggalluvial StatStratum geom_flow geom_stratum to_lodes_form geom_alluvium
 #' @importFrom dplyr %>% mutate
 #' 

--- a/R/alluvialClones.R
+++ b/R/alluvialClones.R
@@ -64,8 +64,7 @@
 #' [hcl.pals][grDevices::hcl.pals].
 #'
 #' @importFrom ggalluvial StatStratum geom_flow geom_stratum to_lodes_form geom_alluvium
-#' @importFrom dplyr %>% mutate
-#' 
+#'
 #' @export
 #' @concept SC_Functions
 #' @return Alluvial ggplot comparing clone distribution.

--- a/R/clonalBias.R
+++ b/R/clonalBias.R
@@ -43,9 +43,7 @@
 #' @param exportTable Returns the data frame used for forming the graph.
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals].
-#' @import ggplot2
 #' @importFrom quantreg rqss
-#' @importFrom stringr str_sort
 #' @export
 #' @concept SC_Functions
 #' @return ggplot scatter plot with clone bias

--- a/R/clonalCluster.R
+++ b/R/clonalCluster.R
@@ -38,7 +38,7 @@
 #' @importFrom igraph set_vertex_attr V union
 #' @importFrom plyr join
 #' @importFrom dplyr bind_rows summarize
-#' @importFrom stringr str_split str_replace_all
+#' @importFrom stringr str_replace_all
 #' @importFrom rlang %||%
 #' @importFrom SummarizedExperiment colData<- colData
 #' @importFrom stats na.omit

--- a/R/clonalCluster.R
+++ b/R/clonalCluster.R
@@ -37,7 +37,6 @@
 #' @importFrom stringdist stringdist
 #' @importFrom igraph set_vertex_attr V union
 #' @importFrom plyr join
-#' @importFrom dplyr bind_rows summarize
 #' @importFrom stringr str_replace_all
 #' @importFrom rlang %||%
 #' @importFrom SummarizedExperiment colData<- colData

--- a/R/clonalCompare.R
+++ b/R/clonalCompare.R
@@ -47,10 +47,6 @@
 #' @param exportTable Returns the data frame used for forming the graph
 #' @param palette Colors to use in visualization - input any
 #' \link[grDevices]{hcl.pals}
-
-#' @import ggplot2
-#' @importFrom stringr str_sort
-#'
 #' @export
 #' @concept Visualizing_Clones
 #' @return ggplot of the proportion of total sequencing read of

--- a/R/clonalDiversity.R
+++ b/R/clonalDiversity.R
@@ -67,10 +67,8 @@
 #' @param return.boots export boot strapped values calculated - 
 #' will automatically exportTable = TRUE.
 #' @param skip.boots remove down sampling and boot strapping from the calculation.
-#' @importFrom stringr str_sort str_split
 #' @importFrom reshape2 melt
 #' @importFrom dplyr sample_n
-#' @import ggplot2
 #' @export
 #' @concept Visualizing_Clones
 #' @return ggplot of the diversity of clones by group

--- a/R/clonalDiversity.R
+++ b/R/clonalDiversity.R
@@ -67,7 +67,7 @@
 #' @param return.boots export boot strapped values calculated - 
 #' will automatically exportTable = TRUE.
 #' @param skip.boots remove down sampling and boot strapping from the calculation.
-#' @importFrom reshape2 melt
+#'
 #' @importFrom dplyr sample_n
 #' @export
 #' @concept Visualizing_Clones

--- a/R/clonalHomeostasis.R
+++ b/R/clonalHomeostasis.R
@@ -30,8 +30,6 @@
 #' environment in addition to the visualization.
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals].
-#' @import ggplot2
-#' @importFrom stringr str_split
 #' @importFrom reshape2 melt
 #' @importFrom dplyr bind_rows
 #' @export

--- a/R/clonalHomeostasis.R
+++ b/R/clonalHomeostasis.R
@@ -30,8 +30,7 @@
 #' environment in addition to the visualization.
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals].
-#' @importFrom reshape2 melt
-#' @importFrom dplyr bind_rows
+#'
 #' @export
 #' @concept Visualizing_Clones
 #' @return ggplot of the space occupied by the specific proportion of clones

--- a/R/clonalLength.R
+++ b/R/clonalLength.R
@@ -29,11 +29,9 @@
 #' @param exportTable Returns the data frame used for forming the graph.
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals]
-#' @importFrom stringr str_split
-#' @importFrom ggplot2 ggplot
 #' @export
 #' @concept Visualizing_Clones
-#' @return ggplot of the discrete or relative length distributions of 
+#' @return ggplot of the discrete or relative length distributions of
 #' clone sequences
 clonalLength <- function(input.data, 
                          cloneCall = "aa", 

--- a/R/clonalNetwork.R
+++ b/R/clonalNetwork.R
@@ -48,10 +48,10 @@
 #' @param exportClones Exports a table of clones that are shared
 #' across multiple identity groups and ordered by the total number
 #' of clone copies.
-#' @param palette Colors to use in visualization - input any 
+#' @param palette Colors to use in visualization - input any
 #' [hcl.pals][grDevices::hcl.pals].
 #' @importFrom igraph graph_from_data_frame V `V<-`
-#' @importFrom dplyr %>% group_by select summarize_all count n across all_of desc
+#' @importFrom dplyr summarize_all count across all_of desc
 #' @importFrom tidygraph as_tbl_graph activate
 #' @importFrom ggraph ggraph geom_edge_bend  geom_node_point scale_edge_colour_gradientn circle guide_edge_colourbar
 #' @importFrom stats setNames

--- a/R/clonalNetwork.R
+++ b/R/clonalNetwork.R
@@ -50,9 +50,6 @@
 #' of clone copies.
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals].
-
-#' @import ggplot2
-#' @importFrom stringr str_sort
 #' @importFrom igraph graph_from_data_frame V `V<-`
 #' @importFrom dplyr %>% group_by select summarize_all count n across all_of desc
 #' @importFrom tidygraph as_tbl_graph activate

--- a/R/clonalOccupy.R
+++ b/R/clonalOccupy.R
@@ -35,8 +35,7 @@
 #' environment in addition to the visualization
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals]
-#' @importFrom dplyr %>% group_by mutate count
-#' @importFrom reshape2 melt
+#' @importFrom dplyr count
 #' @export
 #' @concept SC_Functions
 #' @return Stacked bar plot of counts of cells by clone frequency group

--- a/R/clonalOccupy.R
+++ b/R/clonalOccupy.R
@@ -37,7 +37,6 @@
 #' [hcl.pals][grDevices::hcl.pals]
 #' @importFrom dplyr %>% group_by mutate count
 #' @importFrom reshape2 melt
-#' @import ggplot2
 #' @export
 #' @concept SC_Functions
 #' @return Stacked bar plot of counts of cells by clone frequency group

--- a/R/clonalOverlap.R
+++ b/R/clonalOverlap.R
@@ -56,7 +56,7 @@
 #' @param exportTable Returns the data frame used for forming the graph
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals]
-#' @importFrom stringr str_sort str_to_title
+#' @importFrom stringr str_to_title
 #' @importFrom reshape2 melt
 #' @importFrom stats quantile
 #' @export

--- a/R/clonalOverlap.R
+++ b/R/clonalOverlap.R
@@ -57,7 +57,6 @@
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals]
 #' @importFrom stringr str_to_title
-#' @importFrom reshape2 melt
 #' @importFrom stats quantile
 #' @export
 #' @concept Visualizing_Clones

--- a/R/clonalOverlay.R
+++ b/R/clonalOverlay.R
@@ -31,8 +31,7 @@
 #' cut.category variable in the meta data of the single-cell object.
 #' @param bins The number of contours to the overlay
 #' @param facet.by meta data variable to facet the comparison
-#' 
-#' @import ggplot2
+#'
 #' @importFrom SeuratObject Embeddings
 #' @export
 #' @concept SC_Functions

--- a/R/clonalProportion.R
+++ b/R/clonalProportion.R
@@ -31,9 +31,6 @@
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals]
 #'
-#' @importFrom reshape2 melt
-#' @importFrom dplyr bind_rows n
-#'
 #' @export
 #' @concept Visualizing_Clones
 #' @return ggplot of the space occupied by the specific rank of clones

--- a/R/clonalProportion.R
+++ b/R/clonalProportion.R
@@ -31,8 +31,6 @@
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals]
 #'
-#' @import ggplot2
-#' @importFrom stringr str_sort
 #' @importFrom reshape2 melt
 #' @importFrom dplyr bind_rows n
 #'

--- a/R/clonalQuant.R
+++ b/R/clonalQuant.R
@@ -28,7 +28,6 @@
 #' @param exportTable Returns the data frame used for forming the graph
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals]
-#' @import ggplot2
 #' @export
 #' @concept Visualizing_Clones
 #' @return ggplot of the total or relative unique clones

--- a/R/clonalRarefaction.R
+++ b/R/clonalRarefaction.R
@@ -37,9 +37,8 @@
 #' environment in addition to the visualization.
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals].
-#' 
+#'
 #' @importFrom iNEXT iNEXT ggiNEXT
-#' @import ggplot2
 #' @export
 #' @concept Visualizing_Clones
 clonalRarefaction <- function(input.data,

--- a/R/clonalScatter.R
+++ b/R/clonalScatter.R
@@ -32,9 +32,7 @@
 #' @param exportTable Returns the data frame used for forming the graph.
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals].
-#' 
-#' @import ggplot2
-#' 
+#'
 #' @export
 #' @concept Visualizing_Clones
 #' @return ggplot of the relative clone numbers between two sequencing runs or groups

--- a/R/clonalSizeDistribution.R
+++ b/R/clonalSizeDistribution.R
@@ -50,7 +50,6 @@
 #' @param exportTable Returns the data frame used for forming the graph.
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals].
-#' @import ggplot2 
 #' @importFrom dplyr bind_rows
 #' @importFrom ggdendro dendro_data segment label
 #' @importFrom stats hclust optim pgamma as.dist

--- a/R/clonalSizeDistribution.R
+++ b/R/clonalSizeDistribution.R
@@ -30,34 +30,34 @@
 #' 
 #' @examples
 #' #Making combined contig data
-#' combined <- combineTCR(contig_list, 
-#'                         samples = c("P17B", "P17L", "P18B", "P18L", 
+#' combined <- combineTCR(contig_list,
+#'                         samples = c("P17B", "P17L", "P18B", "P18L",
 #'                                     "P19B","P19L", "P20B", "P20L"))
 #' clonalSizeDistribution(combined, cloneCall = "strict", method="ward.D2")
 #'
-#' @param input.data The product of [combineTCR()], 
+#' @param input.data The product of [combineTCR()],
 #' [combineBCR()], or [combineExpression()].
-#' @param cloneCall How to call the clone - VDJC gene (**gene**), 
+#' @param cloneCall How to call the clone - VDJC gene (**gene**),
 #' CDR3 nucleotide (**nt**), CDR3 amino acid (**aa**),
-#' VDJC gene + CDR3 nucleotide (**strict**) or a custom variable 
-#' in the data. 
-#' @param chain indicate if both or a specific chain should be used - 
+#' VDJC gene + CDR3 nucleotide (**strict**) or a custom variable
+#' in the data.
+#' @param chain indicate if both or a specific chain should be used -
 #' e.g. "both", "TRA", "TRG", "IGH", "IGL".
-#' @param threshold Numerical vector containing the thresholds 
+#' @param threshold Numerical vector containing the thresholds
 #' the grid search was performed over.
 #' @param method The clustering parameter for the dendrogram.
 #' @param group.by The variable to use for grouping.
 #' @param exportTable Returns the data frame used for forming the graph.
-#' @param palette Colors to use in visualization - input any 
+#' @param palette Colors to use in visualization - input any
 #' [hcl.pals][grDevices::hcl.pals].
-#' @importFrom dplyr bind_rows
+#'
 #' @importFrom ggdendro dendro_data segment label
 #' @importFrom stats hclust optim pgamma as.dist
 #' @export
 #' @concept Visualizing_Clones
 #' @return ggplot dendrogram of the clone size distribution
 #' @author Hillary Koch
-
+#'
 clonalSizeDistribution <- function(input.data,
                                    cloneCall ="strict", 
                                    chain = "both", 

--- a/R/combineContigs.R
+++ b/R/combineContigs.R
@@ -193,8 +193,7 @@ combineTCR <- function(input.data,
 #' @param filterNonproductive This option will allow for the removal of 
 #' nonproductive chains if the variable exists in the contig data. Default
 #' is set to TRUE to remove nonproductive contigs.
-#' @importFrom dplyr %>% mutate
-#' @importFrom assertthat assert_that is.flag
+#'
 #' @export
 #' @concept Loading_and_Processing_Contigs
 #' @return List of clones for individual cell barcodes

--- a/R/combineExpression.R
+++ b/R/combineExpression.R
@@ -45,11 +45,10 @@
 #' @param addLabel This will add a label to the frequency header, allowing
 #' the user to try multiple group.by variables or recalculate frequencies after 
 #' subsetting the data.
-#' @importFrom dplyr bind_rows %>% summarise left_join mutate select n all_of coalesce
+#' @importFrom dplyr left_join all_of coalesce
 #' @importFrom  rlang %||% sym :=
 #' @importFrom SummarizedExperiment colData<- colData
 #' @importFrom S4Vectors DataFrame
-#' @importFrom assertthat assert_that is.string is.flag
 #' @export
 #' @concept SC_Functions
 #' @return Single-cell object with clone information added to meta data

--- a/R/exportClones.R
+++ b/R/exportClones.R
@@ -25,7 +25,6 @@
 #' return a data.frame
 #' @param dir directory location to save the csv
 #' @param file.name the csv file name
-#' @importFrom dplyr bind_rows
 #' @importFrom utils write.csv
 #' @export
 #' @concept Loading_and_Processing_Contigs
@@ -57,8 +56,8 @@ exportClones <- function(input.data,
   write.csv(mat, file = filepath)
 }
 
-#' @importFrom dplyr %>% group_by mutate
-.TCRmatchExport<- function(input.data) {
+
+.TCRmatchExport <- function(input.data) {
 
   input.data <- .data.wrangle(input.data, NULL, "CTgene", "TRB")
   

--- a/R/exportClones.R
+++ b/R/exportClones.R
@@ -26,7 +26,6 @@
 #' @param dir directory location to save the csv
 #' @param file.name the csv file name
 #' @importFrom dplyr bind_rows
-#' @importFrom stringr str_split
 #' @importFrom utils write.csv
 #' @export
 #' @concept Loading_and_Processing_Contigs

--- a/R/loadContigs.R
+++ b/R/loadContigs.R
@@ -123,7 +123,6 @@ rmAllNaRowsFromLoadContigs <- function(dfList) {
 }
 
 #Formats TRUST4 data
-#' @importFrom stringr str_split
 .parseTRUST4 <- function(df) {
 
     processChain <- function(data, chain_col) {
@@ -153,7 +152,7 @@ rmAllNaRowsFromLoadContigs <- function(dfList) {
         combined_data[combined_data == ""] <- NA
         combined_data
     })
-    # is it necessary to drop rows that are fully NA with an existing barcode?
+
     .chain.parser(formattedDfs)
 }
 
@@ -265,7 +264,6 @@ rmAllNaRowsFromLoadContigs <- function(dfList) {
   return(df)
 }
 
-#' @importFrom stringr str_split
 .parseImmcantation<- function(df) {
   for (i in seq_along(df)) {
     df[[i]][df[[i]] == ""] <- NA

--- a/R/percentAA.R
+++ b/R/percentAA.R
@@ -21,7 +21,6 @@
 #' @param aa.length The maximum length of the CDR3 amino acid sequence. 
 #' @param exportTable Returns the data frame used for forming the graph.
 #' @param palette Colors to use in visualization - input any [hcl.pals][grDevices::hcl.pals].
-#' @import ggplot2
 #' @importFrom reshape2 melt
 #' @importFrom dplyr mutate_at %>% mutate_if
 #' @export

--- a/R/percentAA.R
+++ b/R/percentAA.R
@@ -21,8 +21,7 @@
 #' @param aa.length The maximum length of the CDR3 amino acid sequence. 
 #' @param exportTable Returns the data frame used for forming the graph.
 #' @param palette Colors to use in visualization - input any [hcl.pals][grDevices::hcl.pals].
-#' @importFrom reshape2 melt
-#' @importFrom dplyr mutate_at %>% mutate_if
+#' @importFrom dplyr mutate_at mutate_if
 #' @export
 #' @concept Summarize_Repertoire
 #' @return ggplot of stacked bar graphs of amino acid proportions

--- a/R/percentGenes.R
+++ b/R/percentGenes.R
@@ -24,8 +24,6 @@
 #' @param exportTable Returns the data frame used for forming the graph.
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals].
-#' @import ggplot2
-#' @importFrom stringr str_split str_sort 
 #' @importFrom reshape2 melt
 #' @export
 #' @concept Summarize_Repertoire

--- a/R/percentGenes.R
+++ b/R/percentGenes.R
@@ -24,7 +24,6 @@
 #' @param exportTable Returns the data frame used for forming the graph.
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals].
-#' @importFrom reshape2 melt
 #' @export
 #' @concept Summarize_Repertoire
 #' @return ggplot of percentage of indicated genes as a heatmap

--- a/R/percentKmer.R
+++ b/R/percentKmer.R
@@ -27,7 +27,6 @@
 #' @param exportTable Returns the data frame used for forming the graph.
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals]
-#' @importFrom reshape2 melt
 #' @importFrom stats mad
 #' @export
 #' @concept Summarize_Repertoire

--- a/R/percentKmer.R
+++ b/R/percentKmer.R
@@ -27,7 +27,6 @@
 #' @param exportTable Returns the data frame used for forming the graph.
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals]
-#' @import ggplot2
 #' @importFrom reshape2 melt
 #' @importFrom stats mad
 #' @export

--- a/R/percentVJ.R
+++ b/R/percentVJ.R
@@ -20,8 +20,6 @@
 #' @param exportTable Returns the data frame used for forming the graph
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals].
-#' @import ggplot2
-#' @importFrom stringr str_split str_sort 
 #' @importFrom reshape2 melt
 #' @export
 #' @concept Summarize_Repertoire

--- a/R/percentVJ.R
+++ b/R/percentVJ.R
@@ -20,7 +20,6 @@
 #' @param exportTable Returns the data frame used for forming the graph
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals].
-#' @importFrom reshape2 melt
 #' @export
 #' @concept Summarize_Repertoire
 #' @return ggplot of percentage of V and J gene pairings as a heatmap

--- a/R/positionalEntropy.R
+++ b/R/positionalEntropy.R
@@ -27,8 +27,7 @@
 #' "shannon", "inv.simpson", "norm.entropy"
 #' @param exportTable Returns the data frame used for forming the graph
 #' @param palette Colors to use in visualization - input any [hcl.pals][grDevices::hcl.pals]
-#' @import ggplot2
-#' @importFrom stringr str_split
+#'
 #' @export
 #' @concept Summarize_Repertoire
 #' @return ggplot of line graph of diversity by position

--- a/R/positionalProperty.R
+++ b/R/positionalProperty.R
@@ -41,7 +41,6 @@
 #' @param exportTable Returns the data frame used for forming the graph
 #' @param palette Colors to use in visualization - input any [hcl.pals][grDevices::hcl.pals]
 #' @importFrom stats qt
-#' @importFrom dplyr %>% summarise n group_by 
 #' @export
 #' @concept Summarize_Repertoire
 #' @return ggplot of line graph of diversity by position

--- a/R/positionalProperty.R
+++ b/R/positionalProperty.R
@@ -40,8 +40,6 @@
 #' "stScales", "tScales", or "VHSE"
 #' @param exportTable Returns the data frame used for forming the graph
 #' @param palette Colors to use in visualization - input any [hcl.pals][grDevices::hcl.pals]
-#' @import ggplot2
-#' @importFrom stringr str_split
 #' @importFrom stats qt
 #' @importFrom dplyr %>% summarise n group_by 
 #' @export

--- a/R/scRepertoire-package.R
+++ b/R/scRepertoire-package.R
@@ -9,5 +9,8 @@
 #' @import ggplot2
 #' @importFrom assertthat assert_that is.count is.flag is.string
 #' @importFrom stringr str_sort str_split
+#' @importFrom dplyr %>% select mutate filter arrange bind_rows group_by n
+#' @importFrom dplyr summarise summarize
+#' @importFrom reshape2 melt
 ## usethis namespace: end
 NULL

--- a/R/scRepertoire-package.R
+++ b/R/scRepertoire-package.R
@@ -5,6 +5,9 @@
 #' @importFrom lifecycle deprecated
 #' @importFrom Rcpp sourceCpp
 #' @useDynLib scRepertoire, .registration = TRUE
+#'
+#' @import ggplot2
 #' @importFrom assertthat assert_that is.count is.flag is.string
+#' @importFrom stringr str_sort str_split
 ## usethis namespace: end
 NULL

--- a/R/startracDiversity.R
+++ b/R/startracDiversity.R
@@ -39,8 +39,7 @@
 #' @param group.by The variable in the meta data to group by, often samples.
 #' @param exportTable Returns the data frame used for forming the graph.
 #' @param palette Colors to use in visualization - input any [hcl.pals][grDevices::hcl.pals].
-#' @importFrom reshape2 melt
-#' @importFrom dplyr %>% mutate group_by
+#'
 #' @export
 #' @concept SC_Functions
 #' @return ggplot object of Startrac diversity metrics

--- a/R/startracDiversity.R
+++ b/R/startracDiversity.R
@@ -41,7 +41,6 @@
 #' @param palette Colors to use in visualization - input any [hcl.pals][grDevices::hcl.pals].
 #' @importFrom reshape2 melt
 #' @importFrom dplyr %>% mutate group_by
-#' @import ggplot2
 #' @export
 #' @concept SC_Functions
 #' @return ggplot object of Startrac diversity metrics

--- a/R/typecheck.R
+++ b/R/typecheck.R
@@ -38,6 +38,10 @@ assertthat::on_failure(is_named_numeric) <- function(call, env) {
 
 # functions
 
-assertthat::on_failure(`%in%`) <- function(call, env) {
+isIn <- function(x, table) {
+    x %in% table
+}
+
+assertthat::on_failure(isIn) <- function(call, env) {
     paste0(deparse(call$x), " is not in ", deparse(call$table))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -57,7 +57,7 @@
   })
 }
 
-#' @importFrom dplyr %>% group_by arrange desc ungroup count mutate
+#' @importFrom dplyr desc ungroup count
 #' @importFrom rlang ensym !!
 .clone.counter <- function(meta,
                            group.by, 
@@ -164,7 +164,6 @@
     df
 }
 
-#' @importFrom dplyr bind_rows
 #' @keywords internal
 .bound.input.return <- function(df) {
   if (is_seurat_or_se_object(df)) {
@@ -264,7 +263,7 @@
 }
 
 #Removing extra clones in barcodes with > 2 productive contigs
-#' @importFrom dplyr group_by %>% slice_max
+#' @importFrom dplyr slice_max
 #' @keywords internal
 .filteringMulti <- function(x) {
     x <- x %>%
@@ -290,7 +289,7 @@
 
 
 #Filtering NA contigs out of single-cell expression object
-#' @importFrom dplyr %>% transmute
+#' @importFrom dplyr transmute
 #' @importFrom SingleCellExperiment colData
 #' @keywords internal
 .filteringNA <- function(sc) {
@@ -312,7 +311,6 @@
 
 #Organizing list of contigs for visualization
 #' @keywords internal
-#' @importFrom dplyr %>% group_by n summarise
 .parseContigs <- function(df, i, names, cloneCall) {
     data <- df[[i]]
     data1 <- data %>% 
@@ -371,7 +369,6 @@
 # but now also constructs Con.df and runs the parseTCR algorithm on it, all in Rcpp
 #' @author Gloria Kraus, Nick Bormann, Nicky de Vrij, Nick Borcherding, Qile Yang
 #' @keywords internal
-#' @importFrom dplyr %>% arrange
 .constructConDfAndParseTCR <- function(data2) {
   rcppConstructConDfAndParseTCR(
     data2 %>% dplyr::arrange(., chain, cdr3_nt),
@@ -488,7 +485,6 @@
 
 #Sorting the V/D/J/C gene sequences for T and B cells
 #' @importFrom stringr str_c str_replace_na
-#' @importFrom dplyr bind_rows mutate %>%
 #' @keywords internal
 .makeGenes <- function(cellType, data2, chain1, chain2) {
     if(cellType %in% c("T")) {
@@ -575,7 +571,6 @@ is_df_or_list_of_df <- function(x) {
 # nucleotide sequence.
 #' @importFrom stringdist stringdist
 #' @importFrom igraph graph_from_data_frame components graph_from_edgelist
-#' @importFrom dplyr bind_rows filter
 #' @keywords internal
 .lvCompare <- function(dictionary, gene, chain, threshold, exportGraph = FALSE) {
   overlap <- NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,7 +1,6 @@
 # readability functions with appropriate assertthat fail messages
 "%!in%" <- Negate("%in%")
 
-#'@importFrom stringr str_sort
 .ordering.function <- function(vector, 
                                group.by,
                                data.frame) {
@@ -14,7 +13,6 @@
 }
 
 #Use to shuffle between chains
-#' @importFrom stringr str_split
 #' @keywords internal
 #' @author Ye-Lin Son, Nick Borcherding
 .off.the.chain <- function(dat, chain, cloneCall, check = TRUE) {
@@ -79,7 +77,6 @@
 }
 
 
-#' @importFrom stringr str_split
 .aa.counter <- function(input.data, cloneCall, aa.length) {
     lapply(input.data, function(x) {
         strings <- x[,cloneCall]
@@ -576,7 +573,6 @@ is_df_or_list_of_df <- function(x) {
 
 # Calculates the normalized Levenshtein Distance between the contig 
 # nucleotide sequence.
-#' @importFrom stringr str_split str_sort
 #' @importFrom stringdist stringdist
 #' @importFrom igraph graph_from_data_frame components graph_from_edgelist
 #' @importFrom dplyr bind_rows filter

--- a/R/vizGenes.R
+++ b/R/vizGenes.R
@@ -33,7 +33,7 @@
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals].
 #' @importFrom stats sd
-#' @importFrom dplyr bind_rows %>% group_by mutate ungroup summarise
+#' @importFrom dplyr ungroup
 #' @export
 #' @concept Visualizing_Clones
 #' @return ggplot bar diagram or heatmap of gene usage

--- a/R/vizGenes.R
+++ b/R/vizGenes.R
@@ -32,8 +32,6 @@
 #' @param exportTable Returns the data frame used for forming the graph.
 #' @param palette Colors to use in visualization - input any 
 #' [hcl.pals][grDevices::hcl.pals].
-#' @import ggplot2
-#' @importFrom stringr str_split
 #' @importFrom stats sd
 #' @importFrom dplyr bind_rows %>% group_by mutate ungroup summarise
 #' @export

--- a/man/clonalSizeDistribution.Rd
+++ b/man/clonalSizeDistribution.Rd
@@ -73,8 +73,8 @@ Where:
 }
 \examples{
 #Making combined contig data
-combined <- combineTCR(contig_list, 
-                        samples = c("P17B", "P17L", "P18B", "P18L", 
+combined <- combineTCR(contig_list,
+                        samples = c("P17B", "P17L", "P18B", "P18L",
                                     "P19B","P19L", "P20B", "P20L"))
 clonalSizeDistribution(combined, cloneCall = "strict", method="ward.D2")
 

--- a/man/loadContigs.Rd
+++ b/man/loadContigs.Rd
@@ -16,28 +16,28 @@ elements}
 }
 \value{
 List of contigs for compatibility  with \code{\link[=combineTCR]{combineTCR()}} or
-\code{\link[=combineBCR]{combineBCR()}}
+\code{\link[=combineBCR]{combineBCR()}}. Note that rows which are fully NA are dropped from the
+final output.
 }
 \description{
 This function generates a contig list and formats the data to allow for
 function with  \code{\link[=combineTCR]{combineTCR()}} or \code{\link[=combineBCR]{combineBCR()}}. If
 using data derived from filtered outputs of 10X Genomics, there is no
 need to use this function as the data is already compatible.
-}
-\details{
+
 The files that this function parses includes:
 \itemize{
-\item 10X =  "filtered_contig_annotations.csv"
-\item AIRR = "airr_rearrangement.tsv"
-\item BD = "Contigs_AIRR.tsv"
-\item Dandelion = "all_contig_dandelion.tsv"
-\item Immcantation = "data.tsv"
-\item JSON = ".json"
-\item ParseBio = "barcode_report.tsv"
-\item MiXCR = "clones.tsv"
-\item Omniscope = ".csv"
-\item TRUST4 = "barcode_report.tsv"
-\item WAT3R = "barcode_results.csv"
+\item \strong{10X}: \code{"filtered_contig_annotations.csv"}
+\item \strong{AIRR}: \code{"airr_rearrangement.tsv"}
+\item \strong{BD}: \code{"Contigs_AIRR.tsv"}
+\item \strong{Dandelion}: \code{"all_contig_dandelion.tsv"}
+\item \strong{Immcantation}: \code{"data.tsv"}
+\item \strong{JSON}: \code{".json"}
+\item \strong{ParseBio}: \code{"barcode_report.tsv"}
+\item \strong{MiXCR}: \code{"clones.tsv"}
+\item \strong{Omniscope}: \code{".csv"}
+\item \strong{TRUST4}: \code{"barcode_report.tsv"}
+\item \strong{WAT3R}: \code{"barcode_results.csv"}
 }
 }
 \examples{

--- a/tests/testthat/test-loadContigs.R
+++ b/tests/testthat/test-loadContigs.R
@@ -1,62 +1,101 @@
 # test script for loadContigs.R - testcases are NOT comprehensive!
 
 test_that("loadContigs works", {
-    TRUST4 <- read.csv("https://www.borch.dev/uploads/contigs/TRUST4_contigs.csv")
-    trial1 <- loadContigs(TRUST4, format = "TRUST4")
-    expect_identical(trial1, 
-                     getdata("load", "loadContigs_TRUST4")
-    )
-    
     
     BD <- read.csv("https://www.borch.dev/uploads/contigs/BD_contigs.csv")
     trial2 <- loadContigs(BD, format = "BD")
     expect_identical(trial2, 
-                     getdata("load", "loadContigs_BD")
+                     rmAllNaRowsFromLoadContigs(getdata("load", "loadContigs_BD"))
     )
     
     WAT3R <- read.csv("https://www.borch.dev/uploads/contigs/WAT3R_contigs.csv")
     trial3 <- loadContigs(WAT3R, format = "WAT3R")
     expect_identical(trial3, 
-                     getdata("load", "loadContigs_WAT3R")
+                     rmAllNaRowsFromLoadContigs(getdata("load", "loadContigs_WAT3R"))
     )
     
     data("contig_list")
     trial4 <- loadContigs(contig_list[[1]], format = "10X")
     expect_identical(trial4, 
-                     getdata("load", "loadContigs_10x")
+                     rmAllNaRowsFromLoadContigs(getdata("load", "loadContigs_10x"))
     )
     
     
     MIXCR <- read.csv("https://www.borch.dev/uploads/contigs/MIXCR_contigs.csv")
     trial5 <- loadContigs(MIXCR, format = "MiXCR")
     expect_identical(trial5, 
-                     getdata("load", "loadContigs_MiXCR")
+                     rmAllNaRowsFromLoadContigs(getdata("load", "loadContigs_MiXCR"))
     )
     
     Immcantation <- read.csv("https://www.borch.dev/uploads/contigs/Immcantation_contigs.csv")
     trial6 <- loadContigs(Immcantation, format = "Immcantation")
     expect_identical(trial6, 
-                     getdata("load", "loadContigs_Immcantation")
+                     rmAllNaRowsFromLoadContigs(getdata("load", "loadContigs_Immcantation"))
     )
     
     OS <- read.csv("https://www.borch.dev/uploads/contigs/OS_contigs2.csv")
     trial7 <- loadContigs(OS, format = "Omniscope")
     expect_identical(trial7, 
-                     getdata("load", "loadContigs_Omniscope")
+                     rmAllNaRowsFromLoadContigs(getdata("load", "loadContigs_Omniscope"))
     )
     
     Parse <- read.csv("https://www.borch.dev/uploads/contigs/Parse_contigs.csv")
     trial8 <- loadContigs(Parse, format = "ParseBio")
     expect_identical(trial8, 
-                     getdata("load", "loadContigs_Parse")
+                     rmAllNaRowsFromLoadContigs(getdata("load", "loadContigs_Parse"))
     )
     
     Dandelion <- read.csv("https://www.borch.dev/uploads/contigs/Dandelion_contigs.csv")
     trial9 <- loadContigs(Dandelion, format = "Dandelion")
     expect_identical(trial9, 
-                     getdata("load", "loadContigs_Dandelion")
+                     rmAllNaRowsFromLoadContigs(getdata("load", "loadContigs_Dandelion"))
     )
-}) 
+})
+
+test_that("loadContigs(format='TRUST4') works", {
+
+    TRUST4 <- read.csv("https://www.borch.dev/uploads/contigs/TRUST4_contigs.csv")
+    expect_identical(
+        loadContigs(TRUST4, format = "TRUST4"), 
+        rmAllNaRowsFromLoadContigs(getdata("load", "loadContigs_TRUST4"))
+    )
+
+    oneRowTrust4Input <- structure(
+        list(
+            `#barcode` = "CGTAGCGGTGATAAGT-1",
+            cell_type = "B",
+            chain1 = "*",
+            chain2 = "IGKV1D-43,*,IGKJ1,IGKC,TGTCAACAGTATAGTAGTGTCCCCTGGACGTTC,CQQYSSVPWTF,6.00,CGTAGCGGTGATAAGT-1_2,76.00,0",
+            secondary_chain1 = "*",
+            secondary_chain2 = "*"
+        ),
+        row.names = c(NA, -1L),
+        class = "data.frame"
+    )
+
+    expectedParsedTrust4Data <- list(
+        structure(
+            list(
+                barcode = "CGTAGCGGTGATAAGT-1",
+                v_gene = "IGKV1D-43",
+                d_gene = "None",
+                j_gene = "IGKJ1",
+                c_gene = "IGKC",
+                cdr3_nt = "TGTCAACAGTATAGTAGTGTCCCCTGGACGTTC",
+                cdr3 = "CQQYSSVPWTF",
+                reads = "6.00",
+                chain = "IGK"
+            ),
+            row.names = 1L,
+            class = "data.frame"
+        )
+    )
+
+    expect_identical(
+        loadContigs(oneRowTrust4Input, format = "TRUST4"),
+        expectedParsedTrust4Data
+    )
+})
 
 # TODO Add tests for .json and AIRR
 # TODO Would be nice to have a dir option


### PR DESCRIPTION
adresses concern in #430 about redundant rows in the output of loadContigs. Only significant changes are in [R/loadContigs.R](https://github.com/ncborcherding/scRepertoire/pull/442/files#diff-8f4ce566e541bc33ffd94f88c3a0087fcdfb8329e040790016d0e790ca1e23fa), the rest is just some cleanup of redundant import statements