### PR TITLE
fix shuffling of cell barcodes in SingleCellExperiment object

### DIFF
--- a/R/combineExpression.R
+++ b/R/combineExpression.R
@@ -203,9 +203,7 @@ combineExpression <- function(input.data,
       full_data <- merge(colData(sc.data), PreMeta[rownames, , drop = FALSE], by = "row.names", all.x = TRUE)
       rownames(full_data) <- full_data[, 1]
       full_data  <- full_data[, -1]
-      colData(sc.data) <- DataFrame(full_data[, combined_col_names])
-      
-      rownames(colData(sc.data)) <- rownames  
+      colData(sc.data) <- DataFrame(full_data[, combined_col_names])  
     }
     if (filterNA) { 
       sc.data <- .filteringNA(sc.data) 

--- a/R/combineExpression.R
+++ b/R/combineExpression.R
@@ -201,6 +201,8 @@ combineExpression <- function(input.data,
       
       combined_col_names <- unique(c(colnames(colData(sc.data)), colnames(PreMeta)))
       full_data <- merge(colData(sc.data), PreMeta[rownames, , drop = FALSE], by = "row.names", all.x = TRUE)
+      # at this point, the rows in full_data are shuffled. match back with the original colData
+      full_data <- full_data[match(rownames, full_data[,1]), ]
       rownames(full_data) <- full_data[, 1]
       full_data  <- full_data[, -1]
       colData(sc.data) <- DataFrame(full_data[, combined_col_names])  


### PR DESCRIPTION
Update combineExpression.R to get rid of the line that causes shuffling of the row names

Closes #454 